### PR TITLE
文字入力カウントの修正

### DIFF
--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -47,7 +47,7 @@
                     <label for="comment" class="col-md-2 col-form-label">コメント</label>
                     {{-- 改行を有効にしつつ、エスケープする --}}
                     <div class="col-md-10">
-                        <textarea class="form-control count_comment" id="comment" name="comment" placeholder="画像についてコメントを入力してください" rows="10">{!! e(old('comment')) !!}</textarea>
+                        <textarea class="form-control count_comment" id="comment" name="comment" placeholder="画像についてコメントを入力してください" rows="10">{{ old('comment') }}</textarea>
                         <div>
                             <span class="now_count_comment">0</span> / 150 文字
                         </div>
@@ -111,7 +111,8 @@
     });
 
     $('.count_comment').on('input', function(){
-        let count = $(this).val().length;
+        // textarea の改行はLF:1文字、PHP側バリデーションは改行CRLF:2文字のため、バリデーションに合うよう改行コードを二文字に置き換え
+        let count = $(this).val().replace(/\n/g, "\r\n").length;
         $('.now_count_comment').text(count);
         if (count > 150) {
             $('.now_count_comment').addClass('text-danger');

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -57,7 +57,7 @@
                             @csrf
                             <div class="form-group">
                                 <label for="comment">この投稿について感想など、コメントを追加しませんか？</label>
-                                <textarea class="form-control count_comment" id="comment" name="comment" placeholder="コメントを入力" rows="2">{!! nl2br(e(old('comment'))) !!}</textarea>
+                                <textarea class="form-control count_comment" id="comment" name="comment" placeholder="コメントを入力" rows="2">{{ (old('comment')) }}</textarea>
                                 <div>
                                     <span class="now_count_comment">0</span> / 150 文字
                                 </div>
@@ -108,7 +108,7 @@
 </div>
 <script>
         $('.count_comment').on('input', function(){
-        let count = $(this).val().length;
+        let count = $(this).val().replace(/\n/g, "\r\n").length;
         $('.now_count_comment').text(count);
         if (count > 150) {
             $('.now_count_comment').addClass('text-danger');


### PR DESCRIPTION
closes #24
（１）フォームに入力した際の改行コードは「LF」＝ \n となり、
（２）フォームから送信する際の改行コードは「CRLF」＝ \r\n となっている。
なぜ入力時と送信（保存）時でコードが変化するのか理解しかねるが、そのような仕組みのよう。
\n は一文字、\r\n は二文字扱いということで、
入力した際の文字数と、送信したとき（バリデーション）の文字数が異なっていた。

replace(/\n/g, "\r\n")
上記コードを jQuery のメソッドチェーンに加えたところ、改行が文字入力時に二文字カウントされるようになり、バリデーション側のカウントと整合性が取れるようになった。